### PR TITLE
inetd.c: 'n' undeclared

### DIFF
--- a/networking/inetd.c
+++ b/networking/inetd.c
@@ -526,7 +526,7 @@ static void unregister_rpc(servtab_t *sep)
 			bb_perror_msg("pmap_unset(%u,%u)", sep->se_rpcprog, n);
 	}
 }
-#endif /* FEATURE_INETD_RPC */
+#endif /* CONFIG_FEATURE_INETD_RPC */
 
 static void bump_nofile(void)
 {
@@ -1043,7 +1043,7 @@ static void reread_config_file(int sig UNUSED_PARAM)
 			portno = bb_strtou(sep->se_service, NULL, 10);
 #if ENABLE_FEATURE_INETD_RPC
 			if (is_rpc_service(sep)) {
-				sep->se_rpcprog = n;
+				sep->se_rpcprog = portno;
 				if (errno) { /* se_service is not numeric */
 					struct rpcent *rp = getrpcbyname(sep->se_service);
 					if (rp == NULL) {


### PR DESCRIPTION
This fixes incomplete renaming of `n` in https://github.com/vda-linux/busybox_mirror/commit/ad88be9e7ea4ae74b5b012d75e5b92ff12ca273d

With CONFIG_FEATURE_INETD_RPC :
```
networking/inetd.c: In function 'reread_config_file':
networking/inetd.c:1046:23: error: 'n' undeclared (first use in this function)
     sep->se_rpcprog = n;
                       ^
networking/inetd.c:1046:23: note: each undeclared identifier is reported only once for each function it appears in
```