### PR TITLE
wget: avoid -T crash when timeout support is disabled

### DIFF
--- a/networking/wget.c
+++ b/networking/wget.c
@@ -1546,7 +1546,10 @@ IF_DESKTOP(	"no-parent\0"        No_argument       "\xf0")
 	G.user_agent = "Wget"; /* "User-Agent" header field */
 
 	GETOPT32(argv, "^"
-		"cqSO:o:P:Y:U:T:+"
+		"cqSO:o:P:Y:U:"
+		IF_FEATURE_WGET_TIMEOUT("T:+")
+		/* Keep the option bit stable; accept and ignore -T if disabled. */
+		IF_NOT_FEATURE_WGET_TIMEOUT("T:")
 		/*ignored:*/ "t:"
 		/*ignored:*/ "n::"
 		/* wget has exactly four -n<letter> opts, all of which we can ignore:


### PR DESCRIPTION
When FEATURE_WGET_TIMEOUT is disabled, -T remains in the short option string but its destination is NULL. Parsing it as an integer therefore writes through NULL.

Keep -T in the option string so later option bits and argument destinations remain stable. Parse it as a normal string when FEATURE_WGET_TIMEOUT is disabled; getopt32 then safely ignores the NULL destination.

fix CVE-2026-76014:  https://github.com/mirror/busybox/issues/124